### PR TITLE
Adding instructions for GhostBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Many more native applications, a tool to browse for them, and install them.  Mov
 
 Prebuilt ISOs are available via [GhostBSD](https://www.ghostbsd.org/download) for testing and evaluation.  Packaging for other distributions will come in the future as the project matures.
 
+On an installed GhostBSD system, it is possible to install Gershwin by installed the two following packages:
+```
+ # pkg install gershwin-desktop ghostbsd-gershwin-settings
+```
+
 ## Community Support
 
 All community support tickets and feature requests should be created through our [community issue tracker](https://github.com/gershwin-desktop/issues).


### PR DESCRIPTION
I was looking for a way to install Gershwin on an existing GhostBSD installation, and the only resource I have found was this tweet by @ericbsd :
https://x.com/Ericbsd/status/1964279224711184449

Adding instructions to install Gershwin on existing GhostBSD installations here in the official documentation.

