### PR TITLE
Fix archlinux ISO exceeding GitHub's 2 GiB release limit: boot UEFI via GRUB

### DIFF
--- a/.github/workflows/dev-archlinux.yml
+++ b/.github/workflows/dev-archlinux.yml
@@ -27,8 +27,12 @@ jobs:
       options: --privileged
     timeout-minutes: 120
     steps:
+      # grub is a host tool here, not a shipped package: the 'uefi.grub' bootmode
+      # runs grub-mkstandalone and reads /usr/share/grub/sbat.csv from the
+      # container. mkarchiso hard-fails validation without it.
       - name: Install archiso
-        run: pacman -Syu --noconfirm archiso git
+        run: pacman -Syu --noconfirm archiso git grub
+
 
       - uses: actions/checkout@v4
 
@@ -50,6 +54,41 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/dist-iso"
           cp "$iso_file" "$GITHUB_WORKSPACE/dist-iso/$out_name"
           ls -lh "$GITHUB_WORKSPACE/dist-iso/"
+
+      # GitHub rejects release assets >= 2 GiB ("size must be less than
+      # 2147483648"), and until now that only surfaced in the publish job, ~20
+      # minutes and a full boot gate after the build that caused it. Report the
+      # breakdown and fail here instead. Mirrors the ISO SIZE REPORT in
+      # targets/freebsd/build.sh.
+      - name: ISO size report + 2 GiB release-asset gate
+        run: |
+          set -eu
+          limit=2147483648
+          iso=$(find "$GITHUB_WORKSPACE/dist-iso" -name '*.iso' | head -n 1)
+          size=$(stat -c%s "$iso")
+          echo "=================== ISO SIZE REPORT (archlinux) ==================="
+          echo "--- biggest files in the ISO 9660 tree (MiB) ---"
+          find work/iso -type f -printf '%s\t%p\n' 2>/dev/null | sort -rn | head -12 \
+            | awk -F'\t' '{printf "  %9.1f  %s\n", $1/1048576, $2}' || true
+          echo "--- efiboot.img (UEFI ESP) ---"
+          # With uefi.grub this holds GRUB + the UEFI shell only. If it is ever
+          # ~250 MiB again, something reintroduced systemd-boot and with it a
+          # second copy of the kernel + initramfs + microcode.
+          if [ -f work/efiboot.img ]; then
+            awk -v s="$(stat -c%s work/efiboot.img)" 'BEGIN{printf "  %9.1f  work/efiboot.img\n", s/1048576}'
+          else
+            echo "  (none)"
+          fi
+          echo "--- total ---"
+          awk -v s="$size" -v l="$limit" 'BEGIN{
+            printf "  ISO       %9.1f MiB (%d bytes)\n", s/1048576, s
+            printf "  limit     %9.1f MiB (%d bytes)\n", l/1048576, l
+            printf "  headroom  %9.1f MiB\n", (l-s)/1048576 }'
+          echo "==================================================================="
+          if [ "$size" -ge "$limit" ]; then
+            echo "::error::ISO is $size bytes, at or over GitHub's $limit release-asset limit, so it cannot be published. See the report above and the notes in targets/archlinux/profiledef.sh."
+            exit 1
+          fi
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rc-archlinux.yml
+++ b/.github/workflows/rc-archlinux.yml
@@ -27,8 +27,11 @@ jobs:
       options: --privileged
     timeout-minutes: 120
     steps:
+      # grub is a host tool here, not a shipped package: the 'uefi.grub' bootmode
+      # runs grub-mkstandalone and reads /usr/share/grub/sbat.csv from the
+      # container. mkarchiso hard-fails validation without it.
       - name: Install archiso
-        run: pacman -Syu --noconfirm archiso git
+        run: pacman -Syu --noconfirm archiso git grub
 
       - uses: actions/checkout@v4
 
@@ -42,6 +45,41 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/dist-iso"
           cp "$iso_file" "$GITHUB_WORKSPACE/dist-iso/$out_name"
           ls -lh "$GITHUB_WORKSPACE/dist-iso/"
+
+      # GitHub rejects release assets >= 2 GiB ("size must be less than
+      # 2147483648"), and until now that only surfaced in the publish job, ~20
+      # minutes and a full boot gate after the build that caused it. Report the
+      # breakdown and fail here instead. Mirrors the ISO SIZE REPORT in
+      # targets/freebsd/build.sh.
+      - name: ISO size report + 2 GiB release-asset gate
+        run: |
+          set -eu
+          limit=2147483648
+          iso=$(find "$GITHUB_WORKSPACE/dist-iso" -name '*.iso' | head -n 1)
+          size=$(stat -c%s "$iso")
+          echo "=================== ISO SIZE REPORT (archlinux) ==================="
+          echo "--- biggest files in the ISO 9660 tree (MiB) ---"
+          find work/iso -type f -printf '%s\t%p\n' 2>/dev/null | sort -rn | head -12 \
+            | awk -F'\t' '{printf "  %9.1f  %s\n", $1/1048576, $2}' || true
+          echo "--- efiboot.img (UEFI ESP) ---"
+          # With uefi.grub this holds GRUB + the UEFI shell only. If it is ever
+          # ~250 MiB again, something reintroduced systemd-boot and with it a
+          # second copy of the kernel + initramfs + microcode.
+          if [ -f work/efiboot.img ]; then
+            awk -v s="$(stat -c%s work/efiboot.img)" 'BEGIN{printf "  %9.1f  work/efiboot.img\n", s/1048576}'
+          else
+            echo "  (none)"
+          fi
+          echo "--- total ---"
+          awk -v s="$size" -v l="$limit" 'BEGIN{
+            printf "  ISO       %9.1f MiB (%d bytes)\n", s/1048576, s
+            printf "  limit     %9.1f MiB (%d bytes)\n", l/1048576, l
+            printf "  headroom  %9.1f MiB\n", (l-s)/1048576 }'
+          echo "==================================================================="
+          if [ "$size" -ge "$limit" ]; then
+            echo "::error::ISO is $size bytes, at or over GitHub's $limit release-asset limit, so it cannot be published. See the report above and the notes in targets/archlinux/profiledef.sh."
+            exit 1
+          fi
 
       - uses: actions/upload-artifact@v4
         with:

--- a/targets/archlinux/efiboot/loader/entries/01-archiso-x86_64-linux.conf
+++ b/targets/archlinux/efiboot/loader/entries/01-archiso-x86_64-linux.conf
@@ -1,7 +1,0 @@
-title    Arch Linux (x86_64, UEFI)
-sort-key 01
-linux    /%INSTALL_DIR%/boot/x86_64/vmlinuz-linux
-initrd   /%INSTALL_DIR%/boot/intel-ucode.img
-initrd   /%INSTALL_DIR%/boot/amd-ucode.img
-initrd   /%INSTALL_DIR%/boot/x86_64/initramfs-linux.img
-options  archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% quiet splash

--- a/targets/archlinux/efiboot/loader/loader.conf
+++ b/targets/archlinux/efiboot/loader/loader.conf
@@ -1,2 +1,0 @@
-timeout 0
-default 01-archiso-x86_64-linux.conf

--- a/targets/archlinux/grub/grub.cfg
+++ b/targets/archlinux/grub/grub.cfg
@@ -1,0 +1,100 @@
+# GRUB configuration for the UEFI El Torito boot image.
+#
+# We boot UEFI via GRUB rather than systemd-boot deliberately, and it is a size
+# decision, not a taste one. systemd-boot can only read files from the EFI
+# system partition it was launched from, so mkarchiso has to copy the kernel,
+# initramfs and microcode *into* efiboot.img -- a second full copy on top of the
+# one it already writes to ISO 9660 for syslinux. On this profile the initramfs
+# alone is ~207 MiB, so that duplicate cost ~237 MiB of ISO.
+#
+# GRUB reads iso9660 directly, so efiboot.img only has to carry GRUB itself and
+# the UEFI shell. One copy of the kernel and initramfs, same as the debian and
+# devuan flavors. See targets/archlinux/profiledef.sh for the bootmodes.
+
+# Load partition table and file system modules
+insmod part_gpt
+insmod part_msdos
+insmod fat
+insmod iso9660
+
+# Use graphics-mode output
+if loadfont "${prefix}/fonts/unicode.pf2" ; then
+    insmod all_video
+    set gfxmode="auto"
+    terminal_input console
+    terminal_output console
+fi
+
+# Enable serial console -- the screenshot gate drives the VM over serial.
+insmod serial
+if serial --unit=0 --speed=115200; then
+    terminal_input --append serial
+    terminal_output --append serial
+fi
+
+# Get a human readable platform identifier
+if [ "${grub_platform}" == 'efi' ]; then
+    gershwin_platform='UEFI'
+elif [ "${grub_platform}" == 'pc' ]; then
+    gershwin_platform='BIOS'
+else
+    gershwin_platform="${grub_cpu}-${grub_platform}"
+fi
+
+# Set default menu entry
+default=gershwin
+timeout=5
+timeout_style=menu
+
+
+# Menu entries
+#
+# The microcode images are listed explicitly because this profile's
+# mkinitcpio.conf has no 'microcode' hook, so mkarchiso ships them as external
+# initrds (it logs "External microcode initramfs images will be copied"). The
+# kernel command line matches the syslinux entry in targets/archlinux/syslinux/.
+
+menuentry "Gershwin on Arch Linux (%ARCH%, ${gershwin_platform})" --class arch --class gnu-linux --class gnu --class os --id 'gershwin' {
+    set gfxpayload=keep
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL% quiet splash
+    initrd /%INSTALL_DIR%/boot/intel-ucode.img /%INSTALL_DIR%/boot/amd-ucode.img /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
+}
+
+menuentry "Gershwin on Arch Linux (%ARCH%, ${gershwin_platform}, verbose)" --class arch --class gnu-linux --class gnu --class os --id 'gershwin-verbose' {
+    set gfxpayload=keep
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% archisolabel=%ARCHISO_LABEL%
+    initrd /%INSTALL_DIR%/boot/intel-ucode.img /%INSTALL_DIR%/boot/amd-ucode.img /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
+}
+
+if [ "${grub_platform}" == 'efi' -a "${grub_cpu}" == 'x86_64' -a -f '/boot/memtest86+/memtest.efi' ]; then
+    menuentry 'Run Memtest86+ (RAM test)' --class memtest86 --class memtest --class gnu --class tool {
+        set gfxpayload=800x600,1024x768
+        linux /boot/memtest86+/memtest.efi
+    }
+fi
+
+if [ "${grub_platform}" == 'efi' ]; then
+    if [ "${grub_cpu}" == 'x86_64' -a -f '/shellx64.efi' ]; then
+        menuentry 'UEFI Shell' --class efi {
+            chainloader /shellx64.efi
+        }
+    elif [ "${grub_cpu}" == 'i386' -a -f '/shellia32.efi' ]; then
+        menuentry 'UEFI Shell' --class efi {
+            chainloader /shellia32.efi
+        }
+    fi
+
+    menuentry 'UEFI Firmware Settings' --id 'uefi-firmware' {
+        fwsetup
+    }
+fi
+
+menuentry 'System shutdown' --class shutdown --class poweroff {
+    echo 'System shutting down...'
+    halt
+}
+
+menuentry 'System restart' --class reboot --class restart {
+    echo 'System rebooting...'
+    reboot
+}

--- a/targets/archlinux/grub/loopback.cfg
+++ b/targets/archlinux/grub/loopback.cfg
@@ -1,0 +1,50 @@
+# Boot the ISO from a GRUB loopback on an existing install, without writing it
+# to a USB stick. https://www.supergrubdisk.org/wiki/Loopback.cfg
+#
+# mkarchiso substitutes the %...% placeholders and copies this to
+# /boot/grub/loopback.cfg on ISO 9660. Kept in sync with grub.cfg -- the only
+# difference is how the root device is located (img_dev/img_loop instead of
+# archisolabel).
+
+# Search for the ISO volume
+search --no-floppy --set=gershwin_img_dev --file "${iso_path}"
+probe --set gershwin_img_dev_uuid --fs-uuid "${gershwin_img_dev}"
+
+# Get a human readable platform identifier
+if [ "${grub_platform}" == 'efi' ]; then
+    gershwin_platform='UEFI'
+elif [ "${grub_platform}" == 'pc' ]; then
+    gershwin_platform='BIOS'
+else
+    gershwin_platform="${grub_cpu}-${grub_platform}"
+fi
+
+# Set default menu entry
+default=gershwin
+timeout=5
+timeout_style=menu
+
+
+# Menu entries
+
+menuentry "Gershwin on Arch Linux (%ARCH%, ${gershwin_platform})" --class arch --class gnu-linux --class gnu --class os --id 'gershwin' {
+    set gfxpayload=keep
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% img_dev=UUID=${gershwin_img_dev_uuid} img_loop="${iso_path}" quiet splash
+    initrd /%INSTALL_DIR%/boot/intel-ucode.img /%INSTALL_DIR%/boot/amd-ucode.img /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
+}
+
+menuentry "Gershwin on Arch Linux (%ARCH%, ${gershwin_platform}, verbose)" --class arch --class gnu-linux --class gnu --class os --id 'gershwin-verbose' {
+    set gfxpayload=keep
+    linux /%INSTALL_DIR%/boot/%ARCH%/vmlinuz-linux archisobasedir=%INSTALL_DIR% img_dev=UUID=${gershwin_img_dev_uuid} img_loop="${iso_path}"
+    initrd /%INSTALL_DIR%/boot/intel-ucode.img /%INSTALL_DIR%/boot/amd-ucode.img /%INSTALL_DIR%/boot/%ARCH%/initramfs-linux.img
+}
+
+menuentry 'System shutdown' --class shutdown --class poweroff {
+    echo 'System shutting down...'
+    halt
+}
+
+menuentry 'System restart' --class reboot --class restart {
+    echo 'System rebooting...'
+    reboot
+}

--- a/targets/archlinux/profiledef.sh
+++ b/targets/archlinux/profiledef.sh
@@ -10,10 +10,26 @@ iso_version="$(date +%Y.%m.%d)"
 install_dir="gershwinarch"
 buildmodes=('iso')
 quiet="y"
-bootmodes=('bios.syslinux' 'uefi.systemd-boot')
+# UEFI boots via GRUB, not systemd-boot, to keep the ISO under GitHub's 2 GiB
+# release-asset limit. systemd-boot can only read the EFI system partition it was
+# launched from, so mkarchiso copies the kernel + initramfs + microcode into
+# efiboot.img on top of the copy it already writes to ISO 9660 for syslinux. With
+# a ~207 MiB initramfs (the kms hook bundles ~145 MiB of GPU firmware, stored
+# uncompressed because it is already zstd) that duplicate cost ~237 MiB and
+# pushed the ISO to 2048.0 MiB -- 208 KiB over the limit. GRUB reads iso9660, so
+# efiboot.img carries only GRUB and the UEFI shell. See targets/archlinux/grub/.
+bootmodes=('bios.syslinux' 'uefi.grub')
 arch="x86_64"
 pacman_conf="pacman.conf"
 airootfs_image_type="squashfs"
+# Already the maximum squashfs can do -- do not go looking for a better setting
+# here when the ISO grows. 1M is mksquashfs's hard ceiling on block size
+# ("-b block size not power of two or not between 4096 and 1Mbyte") and the xz
+# dictionary cannot exceed it ("-Xdict-size is larger than block_size"), so both
+# knobs are pinned at their limit. Re-packing the 2026-07-26 airootfs (3597 MiB
+# of file data) every other way measured worse: this = 1463.8 MiB, xz without
+# -Xbcj x86 = 1474.1 MiB, zstd -Xcompression-level 22 = 1523.8 MiB.
+# Size wins come from the boot payload and image contents instead.
 airootfs_image_tool_options=('-comp' 'xz' '-Xbcj' 'x86' '-b' '1M' '-Xdict-size' '1M')
 file_permissions=(
   ["/root"]="0:0:750"


### PR DESCRIPTION
## Problem

`rc-archlinux` and `dev-archlinux` build and pass the boot gate, then fail in **publish**:

```
size must be less than 2147483648
##[error]ISO 'gershwin-on-archlinux-rc-20260731160120-x86_64.iso' did not upload
```

The ISO is **2048.0 MiB** (`ISO image produced: 1048680 sectors` = 2,147,696,640 bytes). GitHub's release-asset limit is 2 GiB = 2,147,483,648. We are over by **208 KiB** — 0.01%.

## This is not a compression problem

The obvious move is to look for better squashfs settings. There aren't any — the profile is already at the format's ceiling, and I confirmed it from mksquashfs directly rather than from the docs:

```
$ mksquashfs ... -b 2M
mksquashfs: -b block size not power of two or not between 4096 and 1Mbyte

$ mksquashfs ... -b 1M -Xdict-size 2M
xz: -Xdict-size is larger than block_size
```

1 MiB is the hard maximum block size, and the xz dictionary cannot exceed the block size, so `-b 1M -Xdict-size 1M` pins both. To be sure, I pulled `airootfs.sfs` out of the published 2026-07-26 ISO and re-packed the 3597 MiB tree every other way. The control reproduced the shipped image to within 0.003% (1,534,889,984 vs 1,534,943,232 bytes), so the comparisons are sound:

| variant | size | vs. current |
|---|---|---|
| **current** `xz -Xbcj x86 -b 1M -Xdict-size 1M` | **1463.8 MiB** | — |
| xz, no BCJ filter | 1474.1 MiB | +10.3 MiB worse |
| zstd `-Xcompression-level 22` | 1523.8 MiB | +60.0 MiB worse |

`profiledef.sh` now records this so the next person doesn't repeat the experiment.

## Cause

The ISO carries the kernel, initramfs and microcode **twice**. Measured from the published 2026-07-26 ISO (1955.9 MiB) by walking its ISO 9660 directory tree:

| | MiB |
|---|---|
| `airootfs.sfs` | 1463.8 |
| `initramfs-linux.img` (ISO 9660) | 207.3 |
| `vmlinuz-linux` (ISO 9660) | 15.7 |
| intel + amd microcode (ISO 9660) | 14.6 |
| `efiboot.img` — **all of the above again** | ~252 |

mkarchiso copies the kernel and initramfs to ISO 9660 unconditionally (`_run_once _make_boot_on_iso9660` is not gated on `bootmodes`) for syslinux/BIOS. The `uefi.systemd-boot` bootmode then copies them a second time into `efiboot.img`, and mkarchiso says why in its own comment:

```bash
# Copy kernel and initramfs to FAT image.
# systemd-boot can only access files from the EFI system partition it was launched from.
_run_once _make_boot_on_fat
```

The initramfs is 207.3 MiB because archiso's `kms` hook bundles GPU firmware — 145 MiB of it, 107 MiB of that nvidia GSP blobs (`gsp-570.144.bin.zst` alone is 51.8 MB). mkinitcpio leaves that in the **uncompressed** early CPIO, because the files are already zstd: 204 MiB of the 207 MiB image is that early CPIO, and re-compressing it with `xz -9` buys only 9%.

## Fix

Switch the UEFI bootmode to `uefi.grub`. GRUB reads iso9660, so it has none of systemd-boot's constraint, and `efiboot.img` only has to carry GRUB and the UEFI shell:

```bash
_make_bootmode_uefi.grub() {
    ...
    # Collect a list of files to calculate the required FAT image size
    efiboot_files=("${isofs_dir}/EFI")     # no kernel, no initramfs, no microcode
```

**This is what the debian and devuan flavors already do**, which is a large part of why they are smaller. Same measurement on their published ISOs:

| | debian | devuan | archlinux |
|---|---|---|---|
| squashfs | 1180.7 MiB | 1198.4 MiB | 1463.8 MiB |
| initrd | 76.8 MiB ×1 | 77.1 MiB ×1 | 207.3 MiB **×2** |
| EFI image | 4.7 MiB | 4.0 MiB | **~252 MiB** |
| total | 1500.9 MiB | 1297.0 MiB | 2048.0 MiB |

(Debian lists `initrd.img` and `initrd.img-6.1.0-51-amd64` twice in its directory tree, but both records point at the same extent — LBA 629291. One copy.)

Expected saving **~220 MiB**, taking the ISO to roughly 1.83 GiB. **Nothing is removed from the image** — same packages, same firmware, same kernel, same squashfs.

## Also: fail at build time, not publish time

Adds an ISO size report and a hard 2 GiB gate to the build job, modeled on the `ISO SIZE REPORT` block in `targets/freebsd/build.sh`. Until now the limit was only discovered in `publish`, ~20 minutes and a full boot gate after the build that caused it. The report breaks out the ISO 9660 tree and `efiboot.img` separately, so a future regression to a ~250 MiB EFI image is obvious at a glance.

## Changes

- `profiledef.sh` — `uefi.systemd-boot` → `uefi.grub`; document why the squashfs options must not be "improved"
- `grub/{grub.cfg,loopback.cfg}` — new, ported from archiso `releng` with Gershwin branding. Lists the microcode initrds explicitly, because this profile's `mkinitcpio.conf` has no `microcode` hook (mkarchiso logs *"External microcode initramfs images will be copied"*), and keeps the syslinux entry's cmdline (`archisobasedir` / `archisolabel` / `quiet splash`)
- `efiboot/` — removed; dead once systemd-boot is gone
- `rc-archlinux.yml`, `dev-archlinux.yml` — install `grub` in the build container (`grub-mkstandalone` and `/usr/share/grub/sbat.csv` are host tools for this bootmode, and mkarchiso hard-fails validation without them); add the size report + gate

## Verification

Everything above is measured from the published ISOs and from archiso 89's source; the ISO build itself has not been run against this change, so **CI on this PR is the real test**. The screenshot gate boots with `-bios OVMF.fd`, so it exercises the new UEFI/GRUB path directly rather than the unchanged BIOS/syslinux path. Two things worth watching on the first green run:

- the size report's `efiboot.img` line, which should be tens of MiB rather than ~250
- the UEFI menu now has a 5s timeout where systemd-boot had `timeout 0`, so the gate's boot takes ~5s longer

One follow-up I measured but deliberately left out, since it changes image contents: expanding the already-zstd firmware and kernel modules so xz can compress them in the squashfs saves a further 60.2 MiB (1463.8 → 1403.6 MiB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)