### PR TITLE
archlinux: track the live repos and replace Xorg with XLibre

### DIFF
--- a/.github/workflows/dev-archlinux.yml
+++ b/.github/workflows/dev-archlinux.yml
@@ -36,6 +36,22 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      # XLibre packages are individually signed, so pacman must trust the key
+      # before pacstrap pulls them. Fetched rather than committed: it is served
+      # from the same GitHub that hosts this checkout, so vendoring would not
+      # remove a trust domain. Pinned by FULL fingerprint -- a swapped or
+      # tampered key fails the build here instead of being silently trusted.
+      - name: Trust the XLibre package signing key
+        run: |
+          set -eu
+          fpr=0C92313001CFCA27627B9098B97F7C613F359424
+          curl -fsSL -o /tmp/xlibre.asc https://xlibre-arch.github.io/xlibre-archlinux.asc
+          gpg --show-keys --with-colons /tmp/xlibre.asc \
+            | awk -F: '/^fpr:/{print $10}' | grep -qx "$fpr"
+          pacman-key --add /tmp/xlibre.asc
+          pacman-key --lsign-key "$fpr"
+          rm -f /tmp/xlibre.asc
+
       - name: Select dev branch for gershwin sources (dev where it exists)
         run: |
           if git ls-remote --exit-code --heads https://github.com/gershwin-desktop/gershwin-developer.git dev >/dev/null 2>&1; then REF=dev; else REF=main; fi

--- a/.github/workflows/dev-archlinux.yml
+++ b/.github/workflows/dev-archlinux.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Trust the XLibre package signing key
         run: |
           set -eu
+          # archlinux:latest ships a populated keyring but no local secret key, and
+          # --lsign-key needs one to sign with. Idempotent on an initialised keyring.
+          pacman-key --init
           fpr=0C92313001CFCA27627B9098B97F7C613F359424
           curl -fsSL -o /tmp/xlibre.asc https://xlibre-arch.github.io/xlibre-archlinux.asc
           gpg --show-keys --with-colons /tmp/xlibre.asc \

--- a/.github/workflows/rc-archlinux.yml
+++ b/.github/workflows/rc-archlinux.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Trust the XLibre package signing key
         run: |
           set -eu
+          # archlinux:latest ships a populated keyring but no local secret key, and
+          # --lsign-key needs one to sign with. Idempotent on an initialised keyring.
+          pacman-key --init
           fpr=0C92313001CFCA27627B9098B97F7C613F359424
           curl -fsSL -o /tmp/xlibre.asc https://xlibre-arch.github.io/xlibre-archlinux.asc
           gpg --show-keys --with-colons /tmp/xlibre.asc \

--- a/.github/workflows/rc-archlinux.yml
+++ b/.github/workflows/rc-archlinux.yml
@@ -35,6 +35,22 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      # XLibre packages are individually signed, so pacman must trust the key
+      # before pacstrap pulls them. Fetched rather than committed: it is served
+      # from the same GitHub that hosts this checkout, so vendoring would not
+      # remove a trust domain. Pinned by FULL fingerprint -- a swapped or
+      # tampered key fails the build here instead of being silently trusted.
+      - name: Trust the XLibre package signing key
+        run: |
+          set -eu
+          fpr=0C92313001CFCA27627B9098B97F7C613F359424
+          curl -fsSL -o /tmp/xlibre.asc https://xlibre-arch.github.io/xlibre-archlinux.asc
+          gpg --show-keys --with-colons /tmp/xlibre.asc \
+            | awk -F: '/^fpr:/{print $10}' | grep -qx "$fpr"
+          pacman-key --add /tmp/xlibre.asc
+          pacman-key --lsign-key "$fpr"
+          rm -f /tmp/xlibre.asc
+
       - name: Build ISO with mkarchiso
         run: |
           set -e

--- a/targets/archlinux/airootfs/etc/pacman.conf
+++ b/targets/archlinux/airootfs/etc/pacman.conf
@@ -9,11 +9,19 @@ Architecture = auto
 SigLevel    = Required DatabaseOptional
 
 #
-# Pin Arch Linux to a certain date
+# Repositories for the running system.
+#
+# Include the mirrorlist rather than naming a server: reflector.service runs on
+# boot and rewrites /etc/pacman.d/mirrorlist with the 20 fastest HTTPS mirrors
+# for wherever the user actually is, and uncomment-mirrors.hook re-opens the full
+# list whenever pacman-mirrorlist updates. Hardcoding a Server here would bypass
+# both, which is what the previous archive.archlinux.org pin did -- it left every
+# user on a frozen snapshot, unable to take updates, with reflector's work
+# silently discarded.
 #
 
 [core]
-Server = https://archive.archlinux.org/repos/2026/03/23/$repo/os/$arch
+Include = /etc/pacman.d/mirrorlist
 
 [extra]
-Server = https://archive.archlinux.org/repos/2026/03/23/$repo/os/$arch
+Include = /etc/pacman.d/mirrorlist

--- a/targets/archlinux/airootfs/etc/pacman.conf
+++ b/targets/archlinux/airootfs/etc/pacman.conf
@@ -25,3 +25,13 @@ Include = /etc/pacman.d/mirrorlist
 
 [extra]
 Include = /etc/pacman.d/mirrorlist
+
+# XLibre, which replaces Xorg. Kept in the shipped config so the installed system
+# can take XLibre updates; customize_airootfs.sh trusts the signing key in this
+# image's own keyring. Unlike core/extra there is no mirrorlist to include -- the
+# project publishes a single origin.
+#
+# Inherits the global "Required DatabaseOptional": packages are individually
+# signed, the repo database is not.
+[xlibre]
+Server = https://packages.xlibre.net/arch/stable/$arch

--- a/targets/archlinux/airootfs/root/customize_airootfs.sh
+++ b/targets/archlinux/airootfs/root/customize_airootfs.sh
@@ -15,8 +15,13 @@ pacman-key --populate archlinux
 # workflow: a swapped key fails here rather than being trusted.
 xlibre_fpr=0C92313001CFCA27627B9098B97F7C613F359424
 curl -fsSL -o /tmp/xlibre.asc https://xlibre-arch.github.io/xlibre-archlinux.asc
-gpg --show-keys --with-colons /tmp/xlibre.asc \
+# Own GNUPGHOME for the fingerprint check: this runs in the airootfs chroot with
+# HOME inherited from the build environment (/github/home on CI), which does not
+# exist in here, and gpg fatals trying to create its homedir under it.
+xlibre_gnupg="$(mktemp -d)"
+GNUPGHOME="$xlibre_gnupg" gpg --show-keys --with-colons /tmp/xlibre.asc \
   | awk -F: '/^fpr:/{print $10}' | grep -qx "$xlibre_fpr"
+rm -rf "$xlibre_gnupg"
 pacman-key --add /tmp/xlibre.asc
 pacman-key --lsign-key "$xlibre_fpr"
 rm -f /tmp/xlibre.asc

--- a/targets/archlinux/airootfs/root/customize_airootfs.sh
+++ b/targets/archlinux/airootfs/root/customize_airootfs.sh
@@ -9,6 +9,18 @@ pacman -Scc --noconfirm
 pacman-key --init
 pacman-key --populate archlinux
 
+# Trust the XLibre signing key in the ISO's own keyring as well, so the running
+# system can install and update XLibre packages -- the [xlibre] repo is in the
+# shipped pacman.conf. Same full-fingerprint pin as the build-time import in the
+# workflow: a swapped key fails here rather than being trusted.
+xlibre_fpr=0C92313001CFCA27627B9098B97F7C613F359424
+curl -fsSL -o /tmp/xlibre.asc https://xlibre-arch.github.io/xlibre-archlinux.asc
+gpg --show-keys --with-colons /tmp/xlibre.asc \
+  | awk -F: '/^fpr:/{print $10}' | grep -qx "$xlibre_fpr"
+pacman-key --add /tmp/xlibre.asc
+pacman-key --lsign-key "$xlibre_fpr"
+rm -f /tmp/xlibre.asc
+
 # Some GNUstep build scripts need /proc
 mount -t proc proc /proc
 

--- a/targets/archlinux/packages.x86_64
+++ b/targets/archlinux/packages.x86_64
@@ -126,8 +126,14 @@ zsh
 #networkmanager
 #dolphin
 #firefox
-xorg-server
-xorg-drivers
+# XLibre replaces Xorg. From the [xlibre] repo (see pacman.conf), not Arch.
+# xlibre-xserver Provides and Conflicts xorg-server, and xlibre-drivers is the
+# repo's own group -- the direct counterpart of Arch's xorg-drivers group, with
+# 18 members (7 input + 11 video) against xorg-drivers' 14.
+# xorg-xinit stays: it is an X client, depends only on libx11/xauth/xrdb/xmodmap,
+# and pulls no X server of its own.
+xlibre-xserver
+xlibre-drivers
 xorg-xinit
 
 # Recovery tools

--- a/targets/archlinux/pacman.conf
+++ b/targets/archlinux/pacman.conf
@@ -103,6 +103,18 @@ Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
 [extra]
 Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
 
+# XLibre, which replaces Xorg. Packages are hosted on the project's own domain
+# rather than GitHub or the AUR, and are individually signed; the workflow trusts
+# the signing key (pinned by full fingerprint) before mkarchiso runs.
+#
+# The global SigLevel above is "Required DatabaseOptional", which is exactly what
+# this repo needs and is why it is not overridden here: every package carries a
+# detached .sig verified against the XLibre Arch maintainers' key, but the repo
+# database itself is unsigned (xlibre.db.sig is a 404). Package contents are
+# authenticated; the index listing them is not.
+[xlibre]
+Server = https://packages.xlibre.net/arch/stable/$arch
+
 # If you want to run 32 bit applications on your x86_64 system,
 # enable the multilib repositories as required here.
 

--- a/targets/archlinux/pacman.conf
+++ b/targets/archlinux/pacman.conf
@@ -89,11 +89,19 @@ LocalFileSigLevel = Optional
 # Pin Arch Linux to a certain date
 #
 
+# Build-time repositories, used by mkarchiso on the CI runner only -- this file
+# is never copied into the ISO (the shipped config is airootfs/etc/pacman.conf).
+#
+# Deliberately the geo-redirecting official mirror rather than
+# Include = /etc/pacman.d/mirrorlist: it resolves identically wherever the runner
+# happens to be and does not depend on the mirrorlist state of the archlinux:latest
+# container. The build host is archlinux:latest, so tracking the live repos keeps
+# host and target in the same universe.
 [core]
-Server = https://archive.archlinux.org/repos/2026/03/23/$repo/os/$arch
+Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
 
 [extra]
-Server = https://archive.archlinux.org/repos/2026/03/23/$repo/os/$arch
+Server = https://geo.mirror.pkgbuild.com/$repo/os/$arch
 
 # If you want to run 32 bit applications on your x86_64 system,
 # enable the multilib repositories as required here.


### PR DESCRIPTION
Completes the Linux-side XLibre migration, after Devuan (#37) and Debian (#38). Two commits, in dependency order.

The branch is still named `archlinux/unpin-repos` from when this was scoped to the first commit only — renaming it would close this PR, so the name is stale but the content is both changes.

## 1. `archlinux: track the live repos instead of a frozen archive snapshot`

Both pacman configs pinned `core`/`extra` to `archive.archlinux.org/repos/2026/03/23`. This moves them to the live repos: the geo-redirecting official mirror for the build, the mirrorlist for the running system. The container stays `archlinux:latest`.

**Why this was necessary.** XLibre for Arch publishes exactly one channel, `stable`, rolling and built against *current* Arch. `xlibre-xserver 25.1.8-3` (built 2026-07-15) needs `libnettle.so.9`:

| | nettle | provides |
|---|---|---|
| snapshot 2026-03-23 | 3.10.2-1 | `libnettle.so.8` |
| current Arch | **4.0-1** | `libnettle.so.9` |

Pacman would have caught none of this — every `%DEPENDS%` in these packages is unversioned — so it would have installed cleanly and then died at runtime with `error while loading shared libraries: libnettle.so.9`, surfacing as a black screen at the gate.

**Why unpin rather than move the pin forward:**

- Arch is a rolling distro. A frozen snapshot is a configuration nobody upstream builds or tests against.
- `archive.archlinux.org` gets no security updates, so the ISO ships steadily more known-vulnerable packages.
- Deferring makes it worse. Four months of drift already produced one hard soname break; a year would produce several at once.
- It is recurring maintenance forever, and each skipped bump raises the risk of the next.

**Note this is the opposite of what Debian just got, deliberately.** Debian's container was pinned (`debian:latest` → `debian:trixie`). Same principle — keep build host and target base in the same universe — pulling opposite ways, because Debian targets a stable release while Arch's target is rolling.

**It also fixes a live bug.** `airootfs/etc/pacman.conf` hardcoded a `Server` line that overrode `/etc/pacman.d/mirrorlist` entirely. `reflector.service` rated the 20 fastest mirrors for each user's location on every boot and **nothing ever read the result**; `uncomment-mirrors.hook` was equally moot. Every user, in every country, was stuck on a March snapshot with no route to updates.

*This commit was verified green on its own — build, boot, login, and desktop — before XLibre was added.*

## 2. `archlinux: replace Xorg with XLibre`

Packages come from the project's own binary repo at `packages.xlibre.net` — **not the AUR** (which would mean executing unreviewed PKGBUILDs at build time) and **not GitHub**. This is the only one of the three flavors whose packages don't come from GitHub at all.

The swap is direct:

| from | to | |
|---|---|---|
| `xorg-server` | `xlibre-xserver` | Provides + Conflicts `xorg-server` |
| `xorg-drivers` | `xlibre-drivers` | the repo's own group — 18 members vs 14 |

`xorg-xinit` stays. Worth calling out: Debian's `xinit` **Recommends** `xserver-xorg` and needed a negative pin to keep Xorg out. Arch's depends only on `libx11`/`xauth`/`xrdb`/`xmodmap` and pulls no X server, and Arch has no Recommends — only optdepends, which aren't installed. So nothing drags Xorg back and no pin is needed here.

### Key handling differs from Debian/Devuan, on purpose

Those vendored the key, because it's served from a maintainer's personal domain — committing it removed a trust domain and a point of failure. This key is served from the same GitHub that hosts this checkout, so committing it would remove nothing. It's **fetched but pinned by full fingerprint**, and the build aborts if what's served doesn't match:

```
0C92313001CFCA27627B9098B97F7C613F359424
XLibre for Arch Linux Maintainers <archlinux-maintainers@xlibre.net>
```

That's an official project role key on the project's own domain — stronger provenance than the individual key behind the Debian/Devuan repos. Trusted in two places: on the runner before `mkarchiso` (pacman verifies signatures during `pacstrap`), and inside the image via `customize_airootfs.sh` so the running system can take updates.

### One security caveat, stated plainly

`SigLevel` stays at the global `Required DatabaseOptional`. Every package carries a detached `.sig` verified against that key, but **the repo database is unsigned** — `xlibre.db.sig` is a 404 and the db carries no `%PGPSIG%` entries. So package *contents* are authenticated while the *index* listing them is not. That's weaker than `core`/`extra`, which sign both, and worth knowing when reviewing.

### Verified before pushing

- `xlibre-xserver 25.1.8-3` needs at most `GLIBC_2.42`; live Arch has `2.43+`
- Every `NEEDED` soname of the X server binary is satisfied by the live repos
- Package signatures verify against the pinned key (checked `xlibre-meta` and `xlibre-xserver`)
- Fingerprint in both workflows and `customize_airootfs.sh` matches the published key exactly
- Key-trust step lands after `Install archiso` and before `Build ISO with mkarchiso` in both `dev-` and `rc-`

🤖 Generated with [Claude Code](https://claude.com/claude-code)