### PR TITLE
Defer plymouth splash setup to install-plymouth.sh in gershwin-system

### DIFF
--- a/targets/archlinux/airootfs/root/customize_airootfs.sh
+++ b/targets/archlinux/airootfs/root/customize_airootfs.sh
@@ -64,4 +64,6 @@ EOF
 umount /proc
 
 # Set boot splash theme
-plymouth-set-default-theme spinner -R
+# Now handled by install-plymouth.sh in gershwin-system (invoked from
+# SystemPrepare.sh), which sets the spinner theme on supported distributions.
+# plymouth-set-default-theme spinner -R

--- a/targets/debian/config/hooks/normal/020-plymouth-theme.chroot
+++ b/targets/debian/config/hooks/normal/020-plymouth-theme.chroot
@@ -1,4 +1,7 @@
 #!/bin/bash
 set -e
 
-plymouth-set-default-theme -R spinner
+# Plymouth theme setup is now handled by install-plymouth.sh in
+# gershwin-system (invoked from SystemPrepare.sh), which detects the
+# distribution and installs/configures plymouth automatically.
+# plymouth-set-default-theme -R spinner

--- a/targets/devuan/build.sh
+++ b/targets/devuan/build.sh
@@ -173,6 +173,8 @@ chroot "${WORK}/rootfs" update-rc.d avahi-daemon defaults
 chroot "${WORK}/rootfs" update-rc.d ssh defaults
 
 # Enable boot splash
+# Plymouth is now handled by install-plymouth.sh in gershwin-system
+# (invoked from SystemPrepare.sh); these were the old manual steps:
 # chroot "${WORK}/rootfs" update-rc.d plymouth defaults
 
 # Configure boot splash theme


### PR DESCRIPTION
plymouth theme setup in the arch/debian/devuan image build steps is now handled by install-plymouth.sh (invoked from SystemPrepare.sh), which detects the distribution and installs/configures plymouth automatically. Package lists are left untouched.